### PR TITLE
safe_joinへの変更

### DIFF
--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -32,7 +32,7 @@
           - else
             = image_tag "sample-1.jpg", width: "100%"
         .show_content__left_inner__post_wrap__post_text
-          = simple_format(h(@post.text))
+          = safe_join(@post.text.split("\n"), tag(:br))
         .show_content__left_inner__edit_delete_button
           - if user_signed_in? && @post.user_id == current_user.id
             .show_content__left_inner__edit_delete_button__submit


### PR DESCRIPTION
# What
simple_formatをsafe_joinに変更。

# Why
simple_formatでは連続する改行が反映されない為。以前記述したsafe_joinは("\n")が、("/n")になっていたから反映されていなかった。