### PR TITLE
AWS S3に画像アップロードを実装後のHerokuのApplication error改善

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,7 +6,7 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
-Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
+# Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 amazon:
   service: S3
   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>


### PR DESCRIPTION
# What
S3の設定をしたが、git push heroku master後に、アプリケーションを開くことが出来なくなった。

# Why
heroku run rails cを使って調べてみると、storage.ymlにおいてtabを使っているとエラーが出ているので修正（storage.ymlではtabではなくspaceでインデントを打つ必要がある）。
しかし、それではGitHub Desktopでコードの変更が認識されない為調べていると、amazon: の前の
"# Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)"
の部分もコメントアウトしてしまっていた為、エラーが出たと判断。修正を行った。