### PR TITLE
carrierwave.rbの修正

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,20 +3,19 @@ require 'carrierwave/storage/file'
 require 'carrierwave/storage/fog'
 
 CarrierWave.configure do |config|
-  if Rails.env.production? # 本番環境の場合はS3へアップロード
-    config.storage :fog
+  if Rails.env.development? || Rails.env.test? #開発とテストは今まで通りに
+    config.storage = :file
+  elsif Rails.env.production? #本番はS3に保存する
+    config.storage = :fog
     config.fog_provider = 'fog/aws'
-    config.fog_directory  = 'simpledesign-note-first-bucket' # バケット名
-    config.fog_public = false
     config.fog_credentials = {
       provider: 'AWS',
-      aws_access_key_id: ENV['S3_ACCESS_KEY_ID'], # アクセスキー
-      aws_secret_access_key: ENV['S3_SECRET_ACCESS_KEY'], # シークレットアクセスキー
-      region: 'ap-northeast-1', # リージョン
-      path_style: true
+      aws_access_key_id: Rails.application.credentials.aws[:access_key_id],
+      aws_secret_access_key: Rails.application.credentials.aws[:secret_access_key],
+# credentials下にaws_access_key_idとaws_secret_access_keyはあるよ
+      region: 'ap-northeast-1'
     }
-  else # 本番環境以外の場合はアプリケーション内にアップロード
-    config.storage :file
-    config.enable_processing = false if Rails.env.test?
+    config.fog_directory  = 'simpledesign-note-first-bucket'
+    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/simpledesign-note-first-bucket'
   end
 end


### PR DESCRIPTION
# What
Missing required arguments: aws_access_key_id, aws_secret_access_key (ArgumentError)が出て、
carrierwave.rbのaws、access_key_idを変更する。

# Why
Rails5.2からRails.application.credentials.aws[:access_key_id]という記述に変わった。